### PR TITLE
copy WebKitLibraries files to Output directory on win/x64.

### DIFF
--- a/webkit/Tools/MiniBrowser/win/CMakeLists.txt
+++ b/webkit/Tools/MiniBrowser/win/CMakeLists.txt
@@ -56,4 +56,23 @@ add_executable(MiniBrowser WIN32 ${TOOLS_DIR}/win/DLLLauncher/DLLLauncherMain.cp
 target_link_libraries(MiniBrowser shlwapi)
 set_target_properties(MiniBrowser PROPERTIES OUTPUT_NAME "MiniBrowser")
 
+if (WIN32)
+file(GLOB WebKitLibraries_binaries
+    "${CMAKE_SOURCE_DIR}/WebKitLibraries/win/bin64/*.dll"
+    "${CMAKE_SOURCE_DIR}/WebKitLibraries/win/bin64/Release/cairo.dll"
+)
+
+add_custom_target(copy_WebKitLibraries_binaries)
+get_target_property(TargetLocation MiniBrowser LOCATION)
+get_filename_component(TargetDir ${TargetLocation} DIRECTORY)
+
+foreach(WebKitLibraryFile ${WebKitLibraries_binaries})
+add_custom_command(TARGET MiniBrowser PRE_BUILD
+                    COMMAND ${CMAKE_COMMAND} -E
+                    copy ${WebKitLibraryFile} ${TargetDir}/../)
+endforeach()
+
+add_dependencies(MiniBrowser copy_WebKitLibraries_binaries)
+endif ()
+
 add_dependencies(MiniBrowser MiniBrowserLib)


### PR DESCRIPTION
- Temporary method for copying WebKitLibraries/win/bin64/*.dll to Output directory.
   : Need to consider platform architectures and build configurations. Fixme later!

@daewoong-jang , Please review this~!!
